### PR TITLE
Refactored OpenGL state setting into pyglet Groups

### DIFF
--- a/game/graphics.py
+++ b/game/graphics.py
@@ -77,14 +77,15 @@ def setup_opengl():
 
 
 class BlockGroup(OrderedGroup):
-    def __init__(self, window, texture):
-        super().__init__(order=0)
+    def __init__(self, window, texture, order=0):
+        super().__init__(order=order)
         self.window = window
         self.texture = texture
         self.rotation = 0, 0
         self.position = 0, 0, 0
 
     def set_state(self):
+        # Bind the texture, and set a 3D projection.
         glEnable(self.texture.target)
         glBindTexture(self.texture.target, self.texture.id)
 
@@ -104,6 +105,7 @@ class BlockGroup(OrderedGroup):
         glTranslatef(-x, -y, -z)
 
     def unset_state(self):
+        # Set a 2D projection when finished.
         glDisable(self.texture.target)
         width, height = self.window.get_size()
         glDisable(GL_DEPTH_TEST)
@@ -127,26 +129,23 @@ class BlockGroup(OrderedGroup):
         return '%s(id=%d)' % (self.__class__.__name__, self.texture.id)
 
 
-# class DisplayGroup(OrderedGroup):
-#     def __init__(self, window):
-#         super().__init__(order=1)
+# class HUDGroup(OrderedGroup):
+#     def __init__(self, window, order=1):
+#         super().__init__(order=order)
 #         self.window = window
 #
-#     def set_state(self):
-#         width, height = self.window.get_size()
-#         glDisable(GL_DEPTH_TEST)
-#         glViewport(0, 0, width, height)
-#         glMatrixMode(GL_PROJECTION)
-#         glLoadIdentity()
-#         glOrtho(0, width, 0, height, -1, 1)
-#         glMatrixMode(GL_MODELVIEW)
-#         glLoadIdentity()
-#
-#     def unset_state(self):
-#         pass
-#
-#     def __hash__(self):
-#         return hash(self.order)
+#     def __lt__(self, other):
+#         if isinstance(other, HUDGroup):
+#             return self.order < other.order
+#         return super().__lt__(other)
 #
 #     def __eq__(self, other):
-#         return self.__class__ is other.__class__
+#         return (self.__class__ is other.__class__ and
+#                 self.order == other.order and
+#                 self.parent == other.parent)
+#
+#     def __hash__(self):
+#         return hash((self.order, self.parent))
+#
+#     def __repr__(self):
+#         return '%s(%d)' % (self.__class__.__name__, self.order)

--- a/game/graphics.py
+++ b/game/graphics.py
@@ -127,25 +127,3 @@ class BlockGroup(OrderedGroup):
 
     def __repr__(self):
         return '%s(id=%d)' % (self.__class__.__name__, self.texture.id)
-
-
-# class HUDGroup(OrderedGroup):
-#     def __init__(self, window, order=1):
-#         super().__init__(order=order)
-#         self.window = window
-#
-#     def __lt__(self, other):
-#         if isinstance(other, HUDGroup):
-#             return self.order < other.order
-#         return super().__lt__(other)
-#
-#     def __eq__(self, other):
-#         return (self.__class__ is other.__class__ and
-#                 self.order == other.order and
-#                 self.parent == other.parent)
-#
-#     def __hash__(self):
-#         return hash((self.order, self.parent))
-#
-#     def __repr__(self):
-#         return '%s(%d)' % (self.__class__.__name__, self.order)

--- a/game/graphics.py
+++ b/game/graphics.py
@@ -78,7 +78,7 @@ def setup_opengl():
 
 class BlockGroup(OrderedGroup):
     def __init__(self, window, texture):
-        super().__init__(order=-1)
+        super().__init__(order=0)
         self.window = window
         self.texture = texture
         self.rotation = 0, 0

--- a/game/scenes.py
+++ b/game/scenes.py
@@ -175,6 +175,9 @@ class GameScene(Scene):
 
         # The crosshairs at the center of the screen.
         self.reticle = self.batch.add(4, GL_LINES, self.hud_group, 'v2i', ('c3B', [0]*12))
+        # The highlight around focused block.
+        self.highlight = self.batch.add(24, GL_LINE_STRIP, self.block_group,
+                                        'v3f/dynamic', ('c3B', [0]*72))
 
         # The label that is displayed in the top left of the canvas.
         self.info_label = pyglet.text.Label('', font_name='Arial', font_size=INFO_LABEL_FONTSIZE,
@@ -269,8 +272,8 @@ class GameScene(Scene):
 
         """
         if not self.initialized:
-            print("initializing..... NOW")
             self.window.clear()
+            self.set_exclusive_mouse(True)
             self.loading_label.text = "Loading..."
             self.loading_label.draw()
             self.model.initialize()
@@ -544,11 +547,9 @@ class GameScene(Scene):
         block = self.model.hit_test(self.position, vector)[0]
         if block:
             x, y, z = block
-            vertex_data = cube_vertices(x, y, z, 0.51)
-            glColor3d(0, 0, 0)
-            glPolygonMode(GL_FRONT_AND_BACK, GL_LINE)
-            pyglet.graphics.draw(24, GL_QUADS, ('v3f/static', vertex_data))
-            glPolygonMode(GL_FRONT_AND_BACK, GL_FILL)
+            self.highlight.vertices[:] = cube_vertices(x, y, z, 0.51)
+        else:
+            self.highlight.vertices[:] = [0] * 72
 
     def draw_label(self):
         """ Draw the label in the top left of the screen.

--- a/game/scenes.py
+++ b/game/scenes.py
@@ -108,6 +108,7 @@ class GameScene(Scene):
 
         # A Group manages setting and unsetting OpenGL state.
         self.block_group = BlockGroup(self.window, pyglet.resource.texture('textures.png'))
+        self.hud_group = pyglet.graphics.OrderedGroup(1)
 
         # Whether or not the window exclusively captures the mouse.
         self.exclusive = False
@@ -165,7 +166,7 @@ class GameScene(Scene):
         self.model = Model(batch=self.batch, group=self.block_group)
 
         # The crosshairs at the center of the screen.
-        self.reticle = self.batch.add(4, GL_LINES, None, 'v2i', ('c3B', [0]*12))
+        self.reticle = self.batch.add(4, GL_LINES, self.hud_group, 'v2i', ('c3B', [0]*12))
 
         # The label that is displayed in the top left of the canvas.
         self.info_label = pyglet.text.Label('', font_name='Arial', font_size=INFO_LABEL_FONTSIZE,
@@ -175,7 +176,7 @@ class GameScene(Scene):
         # Boolean whether to display loading screen.
         self.is_initializing = True
         # Loading screen label displayed in center of canvas.
-        self.loading_label = pyglet.text.Label('Loading...', font_name='Arial', font_size=50,
+        self.loading_label = pyglet.text.Label('', font_name='Arial', font_size=50,
                                                x=self.window.width // 2, y=self.window.height // 2,
                                                anchor_x='center', anchor_y='center',
                                                color=(0, 0, 0, 255))
@@ -370,8 +371,7 @@ class GameScene(Scene):
         if self.exclusive:
             vector = self.get_sight_vector()
             block, previous = self.model.hit_test(self.position, vector)
-            if (button == mouse.RIGHT) or \
-                    ((button == mouse.LEFT) and (modifiers & key.MOD_CTRL)):
+            if button == mouse.RIGHT or (button == mouse.LEFT and modifiers & key.MOD_CTRL):
                 # ON OSX, control + left click = right click.
                 if previous:
                     self.model.add_block(previous, self.block)
@@ -506,10 +506,10 @@ class GameScene(Scene):
         """
         self.window.clear()
         if self.is_initializing:
-            self.draw_label()
+            self.loading_label.text = "Loading..."
             self.loading_label.draw()
-            self.is_initializing = False
             self.loading_label.delete()
+            self.is_initializing = False
         else:
             self.block_group.position = self.position
             self.block_group.rotation = self.rotation

--- a/main.py
+++ b/main.py
@@ -48,7 +48,6 @@ def main():
     window = pyglet.window.Window(width=WIDTH, height=HEIGHT, caption=TITLE,
                                   resizable=RESIZABLE, fullscreen=FULLSCREEN, vsync=VSYNC)
     # Hide the mouse cursor and prevent the mouse from leaving the window.
-    # window.set_exclusive_mouse(True)
     scene_manager = SceneManager(window=window)
     pyglet.clock.schedule_interval(scene_manager.update, 1.0 / TICKS_PER_SEC)
     setup_opengl()


### PR DESCRIPTION
All of the OpenGL state setting and unsetting is now in Groups. This should make it easier to seperate different types of graphics into different render calls. 