### PR TITLE
No waiting for loading of blocks. Only grass loads immediately.

### DIFF
--- a/game/savemanager.py
+++ b/game/savemanager.py
@@ -62,8 +62,11 @@ class SaveManager(object):
             with open(save_file_path, 'rb') as file:
                 loaded_world = pickle.load(file)
 
-            for position, block_type in loaded_world.items():
-                model.add_block(position, block_type, immediate=False)
+            for position, block in loaded_world.items():
+                if block.name == "dirt_with_grass":
+                    model.add_block(position, block, immediate=True)
+                else:
+                    model.add_block(position, block, immediate=False)
 
             self.timestamp_print('Loading completed.')
             return True

--- a/game/scenes.py
+++ b/game/scenes.py
@@ -279,8 +279,8 @@ class GameScene(Scene):
         sector = sectorize(self.position)
         if sector != self.sector:
             self.model.change_sectors(self.sector, sector)
-            if self.sector is None:
-                self.model.process_entire_queue()
+            # if self.sector is None:
+            #     self.model.process_entire_queue()
             self.sector = sector
         m = 8
         dt = min(dt, 0.2)
@@ -607,7 +607,7 @@ class Model(object):
             for x in range(-n, n + 1, s):
                 for z in range(-n, n + 1, s):
                     # create a layer stone an DIRT_WITH_GRASS everywhere.
-                    self.add_block((x, y - 2, z), DIRT_WITH_GRASS, immediate=False)
+                    self.add_block((x, y - 2, z), DIRT_WITH_GRASS, immediate=True)
                     self.add_block((x, y - 3, z), BEDSTONE, immediate=False)
                     if x in (-n, n) or z in (-n, n):
                         # create outer walls.


### PR DESCRIPTION
This small change has the following affect:

1. The entire queue is never processed. 
2. "dirt_with_grass" blocks are shown immediately.
3. Other block types will "pop in" as they are loaded. 

I left the code commented out, in case we want to revert it. However, I think this might be the best way forward. We will need to get smarter about the map loading/creation to improve it. Instead of just loading all "dirt_with_grass" types immediaately, we should instead try to load any blocks that are around the player position. 