### PR TITLE
Example of a help screen

### DIFF
--- a/game/scenemanager.py
+++ b/game/scenemanager.py
@@ -45,7 +45,9 @@ class SceneManager:
 
         # Add the defaults Scenes to the manager
         self.add_scene(MenuScene(self.window))
+        self.add_scene(HelpScene(self.window))
         self.add_scene(GameScene(self.window))
+        # Activate the Menu Scene
         self.change_scene("MenuScene")
 
     def add_scene(self, scene_instance):
@@ -57,11 +59,11 @@ class SceneManager:
         self.scenes[scene_instance.__class__.__name__] = scene_instance
 
     def change_scene(self, scene_name):
-        """Change to a specific Scene, by name.
+        """Change to a specific Scene, by it's class name.
 
-        When changing to a new Scene, any event handlers that are
-        defined will be activated. Any handlers on the current
-        Scene will be removed.
+        When changing to a new Scene, any Window event handlers that
+        are defined on the new Scene will be added. Any handlers on
+        the previously active Scene will be removed.
 
         :param scene_name: A `str` of the desired Scene class name.
         """

--- a/game/scenes.py
+++ b/game/scenes.py
@@ -461,8 +461,10 @@ class GameScene(Scene):
         elif symbol == key.TAB:
             self.flying = not self.flying
         elif symbol == key.F1:
-            self.toggleGui = not self.toggleGui
+            self.scene_manager.change_scene("HelpScene")
         elif symbol == key.F2:
+            self.toggleGui = not self.toggleGui
+        elif symbol == key.F3:
             self.toggleLabel = not self.toggleLabel
         elif symbol == key.F5:
             self.model.save_manager.save_world(self.model)
@@ -868,3 +870,43 @@ class Model(object):
         """
         while self.queue:
             self._dequeue()
+
+
+class HelpScene(Scene):
+    def __init__(self, window):
+        self.window = window
+        self.batch = pyglet.graphics.Batch()
+
+        self.labels = []
+        self.text_strings = ["* Left click mouse to destroy block",
+                             "* Right click mouse to create block",
+                             "* Press keys 1 through 0 to choose block type",
+                             "* Press F2 key to hide block selection",
+                             "* Press F3 key to hide debug stats"]
+        self.spacing = 60
+
+        y_position = self.window.height - self.spacing
+
+        for string in self.text_strings:
+            self.labels.append(pyglet.text.Label(string, font_size=22, x=40, y=y_position,
+                                                 color=(0, 50, 50, 255), batch=self.batch))
+            y_position -= self.spacing
+
+        self.on_resize(*self.window.get_size())
+
+    def on_resize(self, width, height):
+        y_position = height - self.spacing
+        for label in self.labels:
+            label.y = y_position
+            y_position -= self.spacing
+
+    def update(self, dt):
+        pass
+
+    def on_key_press(self, symbol, modifiers):
+        self.scene_manager.change_scene("GameScene")
+        return pyglet.event.EVENT_HANDLED
+
+    def on_draw(self):
+        self.window.clear()
+        self.batch.draw()

--- a/game/scenes.py
+++ b/game/scenes.py
@@ -883,8 +883,12 @@ class HelpScene(Scene):
                              "* Press keys 1 through 0 to choose block type",
                              "* Press F2 key to hide block selection",
                              "* Press F3 key to hide debug stats"]
-        self.spacing = 60
 
+        self.return_label = pyglet.text.Label("Press any key to return to game", font_size=25,
+                                              x=self.window.width // 2, y=20, anchor_x='center',
+                                              color=(0, 50, 50, 255), batch=self.batch)
+
+        self.spacing = 60
         y_position = self.window.height - self.spacing
 
         for string in self.text_strings:


### PR DESCRIPTION
I created an example help screen, in the form of a "HelpScene".
An in-game inventory screen could work the same way. 

There are many things we could change or improve.
1. I just made some sample pyglet.text.Labels for the text. We could add sprites to make it look better.
2. Instead of plain text/sprites, we could create some graphics, such as a fancy box to display the text/sprites in.
3. The background is cleared (to the default blue color). We could display the game graphics in the background, instead of clearning the screen.
